### PR TITLE
Interpolate generic initializer

### DIFF
--- a/Interpolate/Interpolate.swift
+++ b/Interpolate/Interpolate.swift
@@ -51,13 +51,13 @@ public class Interpolate {
      
      - returns: an Interpolate object.
      */
-    public init(from: Interpolatable, to: Interpolatable, function: InterpolationFunction = BasicInterpolation.Linear, apply: (Interpolatable -> ())) {
+    public init<T: Interpolatable>(from: T, to: T, function: InterpolationFunction = BasicInterpolation.Linear, apply: (T -> ())) {
         let fromVector = from.vectorize()
         let toVector = to.vectorize()
         self.current = fromVector
         self.from = fromVector
         self.to = toVector
-        self.apply = apply
+        self.apply = { let _ = ($0 as? T).flatMap(apply) }
         self.function = function
         self.diffVectors = calculateDiff(fromVector, to: toVector)
     }

--- a/InterpolateTests/InterpolateTests.swift
+++ b/InterpolateTests/InterpolateTests.swift
@@ -26,9 +26,7 @@ class InterpolateTests: XCTestCase {
         let to: CGFloat = 10.0
         var progressTest: CGFloat = 0.0
         let interpolation = Interpolate(from: from, to: to, apply: { (result) in
-            if let answer = result as? CGFloat {
-                XCTAssertEqual(progressTest*10, answer)
-            }
+            XCTAssertEqual(progressTest*10, result)
         })
         progressTest = 0.25
         interpolation.progress = progressTest
@@ -43,9 +41,7 @@ class InterpolateTests: XCTestCase {
         let to: CGFloat = 10.0
         var progressTest: CGFloat = 0.0
         let interpolation = Interpolate(from: from, to: to, function: BasicInterpolation.EaseIn) { (result) in
-            if let answer = result as? CGFloat {
-                XCTAssertTrue(progressTest*10 > answer)
-            }
+            XCTAssertTrue(progressTest*10 > result)
         }
         progressTest = 0.25
         interpolation.progress = progressTest
@@ -60,9 +56,7 @@ class InterpolateTests: XCTestCase {
         let to: CGFloat = 10.0
         var progressTest: CGFloat = 0.0
         let interpolation = Interpolate(from: from, to: to, function: BasicInterpolation.EaseOut) { (result) in
-            if let answer = result as? CGFloat {
-                XCTAssertTrue(progressTest*10 < answer)
-            }
+            XCTAssertTrue(progressTest*10 < result)
         }
         progressTest = 0.25
         interpolation.progress = progressTest

--- a/README.md
+++ b/README.md
@@ -26,10 +26,8 @@ Create an Interpolate object with a from value, a to value and an apply closure 
 ```swift
 let colorChange = Interpolate(from: UIColor.whiteColor(),
 to: UIColor.redColor(),
-apply: { [weak self] (result) in
-    if let color = result as? UIColor {
-      self?.view.backgroundColor = color
-    }
+apply: { [weak self] (color) in
+    self?.view.backgroundColor = color
 })
 ```
 
@@ -97,20 +95,16 @@ For smoother animations, consider using any of the following functions: **EaseIn
 let shadowPosition = Interpolate(from: -shadowView.frame.size.width,
 to: (self.view.bounds.size.width - shadowView.frame.size.width)/2,
 function: SpringInterpolation(damping: 30.0, velocity: 0.0, mass: 1.0, stiffness: 100.0),
-apply: { [weak self] (result) in
-  if let originX = result as? CGFloat {
-      self?.shadowView.frame.origin.x = originX
-  }
+apply: { [weak self] (originX) in
+    self?.shadowView.frame.origin.x = originX
 })
 
 // Ease out interpolation
 let groundPosition = Interpolate(from: CGPointMake(0, self.view.bounds.size.height),
 to: CGPointMake(0, self.view.bounds.size.height - 150),
 function: BasicInterpolation.EaseOut,
-apply: { [weak self] (result) in
-    if let origin = result as? CGPoint {
-        self?.groundView.frame.origin = origin
-    }
+apply: { [weak self] (origin) in
+    self?.groundView.frame.origin = origin
 })
 ```
 


### PR DESCRIPTION
Use generic initializer to create Interpolate objects. This way, there is no need to typecast inside the `apply` block, so the code becomes cleaner.

```swift
let colorChange = Interpolate(from: UIColor.whiteColor(), to: UIColor.redColor(), apply: { [weak self] (color) in
    self?.view.backgroundColor = color
})
```

Also, this guarantees that the type of `from` parameter is the same as the type of `to`, so there is no way to write code like this:

```swift
let change = Interpolate(from: UIColor.whiteColor(), to: 10.0, apply: { [weak self] (result) in
    // This will cause a fatal error in calculateDiff
})
```
